### PR TITLE
Typo in your readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ sed -i '/key 108   DPAD_DOWN/c\key 106   DPAD_DOWN' Generic.kl
 sed -i '/key 105   DPAD_LEFT/c\key 103   MEDIA_PREVIOUS' Generic.kl
 sed -i '/key 106   DPAD_RIGHT/c\key 108   MEDIA_NEXT' Generic.kl
 sed -i '/key 163   MEDIA_NEXT/c\key 163   DPAD_RIGHT' Generic.kl
-sed -i '/key 165   MEDIA_NEXT/c\key 165   DPAD_LEFT' Generic.kl
+sed -i '/key 165   MEDIA_PREVIOUS/c\key 165   DPAD_LEFT' Generic.kl
 adb push Generic.kl /system/usr/keylayout/Generic.kl
 adb shell chmod 644 /system/usr/keylayout/Generic.kl
 adb reboot


### PR DESCRIPTION
Checked your buttom remapping and was wondering why i couldn't navigate left.
Well turned out there's a little typo in your readme :)
Btw awesome work, i tried messing around with the keylayout myself but got nowhere, since it didn't cross my mind to use Generic.kl and instead was focusing on mtk-kpd.kl instead.
