### PR TITLE
Missing text in the "Controls" section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Installation instructions can be found here: https://innioasis.app/
 - Play/Pause (Short) (Text Input): Open Keyboard
 - Media Buttons: Play/Pause/Next/Previous/Seek
 - Holding Next + Previous (>5 seconds): Restart Rockbox (Thanks, u/thinkVHS!)
-- Holding Menu/Back + (>10 seconds): Switch between Rockbox and Stock
+- Holding Menu/Back + Play/Pause (>10 seconds): Switch between Rockbox and Stock
 
 ## Themes
 


### PR DESCRIPTION
Hi, while reading through the readme I noticed in the "Controls" section where it mentions switching between stock and Rockbox it only says "Back/Menu +" without mentioning you also need to hold "Play/Pause" so I corrected it for others so they don't have to go looking through reddit like me XD